### PR TITLE
Switch duration seconds metric from u64 to f64

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ const NETWORK_PROTOCOL_VERSION_LABEL: &str = "network.protocol.version";
 /// The OTEL SDKs do support calling for the global meter provider instead of holding a reference
 /// but it seems ideal to avoid extra access to the global meter, which sits behind a RWLock.
 struct HTTPMetricsLayerState {
-    pub server_request_duration: Histogram<u64>,
+    pub server_request_duration: Histogram<f64>,
 }
 
 #[derive(Clone)]
@@ -111,7 +111,7 @@ impl HTTPMetricsLayerBuilder {
     fn make_state(meter: Meter) -> HTTPMetricsLayerState {
         HTTPMetricsLayerState {
             server_request_duration: meter
-                .u64_histogram(Cow::from(HTTP_SERVER_DURATION_METRIC))
+                .f64_histogram(Cow::from(HTTP_SERVER_DURATION_METRIC))
                 .init(),
         }
     }
@@ -217,7 +217,7 @@ where
             this.metrics_state
                 .http_request_duration_start
                 .elapsed()
-                .as_secs(),
+                .as_secs_f64(),
             &labels,
         );
 


### PR DESCRIPTION
Thanks for tower-otel-http-metrics! I noticed that `http.server.request.duration` is (correctly) logged as a number of seconds. However, because it's an integer rather than a float, it's not as useful as it could be.

This PR switches duration from u64 to f64.