### PR TITLE
Upgrade OTEL version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ axum = { features = ["matched-path"], version = "0.7", default-features = false,
 futures-core = { version = "0.3", default-features = false }
 futures-util = { version = "0.3", default-features = false }
 http = { version = "1", features = ["std"], default-features = false }
-opentelemetry = { version = "0.25", features = ["metrics"], default-features = false }
+opentelemetry = { version = "0.26", features = ["metrics"], default-features = false }
 pin-project-lite = { version = "0.2", default-features = false }
 tower = { version = "0.5", default-features = false }
 tower-service = { version = "0.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tower-otel-http-metrics"
 edition = "2021"
-version = "0.7.1"
+version = "0.8.0"
 license = "MIT"
 description = "OpenTelemetry Metrics Middleware for Tower-compatible Rust HTTP servers"
 homepage = "https://github.com/francoposa/tower-otel-http-metrics"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Adding OpenTelementry HTTP Server metrics using the [`Axum`](https://docs.rs/axu
 over a Tower-compatible [`Hyper`](https://docs.rs/hyper/latest/hyper) Service:
 
 ```rust
-use std::borrow::Cow;
 use std::time::Duration;
 
 use axum::routing::{get, post, put, Router};
@@ -73,7 +72,7 @@ async fn main() {
 
     global::set_meter_provider(meter_provider);
     // init our otel metrics middleware
-    let global_meter = global::meter(Cow::from(SERVICE_NAME));
+    let global_meter = global::meter(SERVICE_NAME);
     let otel_metrics_service_layer = tower_otel_http_metrics::HTTPMetricsLayerBuilder::new()
         .with_meter(global_meter)
         .build()
@@ -100,7 +99,6 @@ Adding OpenTelementry HTTP Server metrics to a bare-bones Tower-compatible Servi
 using [`Hyper`](https://docs.rs/crate/hyper/latest):
 
 ```rust
-use std::borrow::Cow;
 use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::time::Duration;
@@ -163,7 +161,7 @@ async fn main() {
 
     global::set_meter_provider(meter_provider);
     // init our otel metrics middleware
-    let global_meter = global::meter(Cow::from(SERVICE_NAME));
+    let global_meter = global::meter(SERVICE_NAME);
     let otel_metrics_service_layer = tower_otel_http_metrics::HTTPMetricsLayerBuilder::new()
         .with_meter(global_meter)
         .build()

--- a/examples/axum-http-service/Cargo.toml
+++ b/examples/axum-http-service/Cargo.toml
@@ -10,8 +10,8 @@ tower_otel_http_metrics = { path = "../../", package = "tower-otel-http-metrics"
 axum = { features = ["http1", "tokio"], version = "0.7", default-features = false }
 bytes = { version = "1", default-features = false }
 http-body-util = { version = "0.1" }
-opentelemetry = { version = "0.25.0", default-features = false }
-opentelemetry_sdk = { version = "0.25.0", features = ["rt-tokio"], default-features = false }
-opentelemetry-semantic-conventions = { version = "0.25.0", default-features = false }
-opentelemetry-otlp = { version = "0.25.0", features = ["metrics", "grpc-tonic"], default-features = false }
+opentelemetry = { version = "0.26", default-features = false }
+opentelemetry_sdk = { version = "0.26", features = ["rt-tokio"], default-features = false }
+opentelemetry-semantic-conventions = { version = "0.26", default-features = false }
+opentelemetry-otlp = { version = "0.26", features = ["metrics", "grpc-tonic"], default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread"], default-features = false }

--- a/examples/axum-http-service/src/main.rs
+++ b/examples/axum-http-service/src/main.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::time::Duration;
 
 use axum::routing::{get, post, put, Router};
@@ -55,7 +54,7 @@ async fn main() {
 
     global::set_meter_provider(meter_provider);
     // init our otel metrics middleware
-    let global_meter = global::meter(Cow::from(SERVICE_NAME));
+    let global_meter = global::meter(SERVICE_NAME);
     let otel_metrics_service_layer = tower_otel_http_metrics::HTTPMetricsLayerBuilder::new()
         .with_meter(global_meter)
         .build()

--- a/examples/tower-http-service/Cargo.toml
+++ b/examples/tower-http-service/Cargo.toml
@@ -11,10 +11,10 @@ bytes = { version = "1", default-features = false }
 hyper = { version = "1", default-features = false }
 http-body-util = { version = "0.1", default-features = false }
 hyper-util = { version = "0.1", features = ["http1", "service", "server", "tokio"], default-features = false }
-opentelemetry = { version = "0.25.0", default-features = false }
-opentelemetry_sdk = { version = "0.25.0", features = ["rt-tokio"], default-features = false }
-opentelemetry-semantic-conventions = { version = "0.25.0", default-features = false }
-opentelemetry-otlp = { version = "0.25.0", features = ["grpc-tonic", "metrics"], default-features = false }
+opentelemetry = { version = "0.26", default-features = false }
+opentelemetry_sdk = { version = "0.26", features = ["rt-tokio"], default-features = false }
+opentelemetry-semantic-conventions = { version = "0.26", default-features = false }
+opentelemetry-otlp = { version = "0.26", features = ["grpc-tonic", "metrics"], default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"], default-features = false }
 tower = { version = "0.5", default-features = false }
 tower-http = { version = "0.6", default-features = false }

--- a/examples/tower-http-service/src/main.rs
+++ b/examples/tower-http-service/src/main.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::time::Duration;
@@ -60,7 +59,7 @@ async fn main() {
 
     global::set_meter_provider(meter_provider);
     // init our otel metrics middleware
-    let global_meter = global::meter(Cow::from(SERVICE_NAME));
+    let global_meter = global::meter(SERVICE_NAME);
     let otel_metrics_service_layer = tower_otel_http_metrics::HTTPMetricsLayerBuilder::new()
         .with_meter(global_meter)
         .build()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ impl fmt::Debug for Error {
 
 impl HTTPMetricsLayerBuilder {
     pub fn default() -> Self {
-        let meter = global::meter(Cow::from(""));
+        let meter = global::meter("");
         HTTPMetricsLayerBuilder { meter: Some(meter) }
     }
 


### PR DESCRIPTION
Upgrades to 0.26. In my testing all I needed to do to get this to work was to update the `global::meter` functions as in the README.md changes.