### PR TITLE
upgrade to opentelemetry 0.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ axum = ["dep:axum"]
 axum = { features = ["matched-path", "macros"], version = "0.7", default-features = false, optional = true }
 futures-util = { version = "0.3", default-features = false }
 http = { version = "1", features = ["std"], default-features = false }
-opentelemetry = { version = "0.26", features = ["metrics"], default-features = false }
+opentelemetry = { version = "0.27", features = ["metrics"], default-features = false }
 pin-project-lite = { version = "0.2", default-features = false }
 tower = { version = "0.5", default-features = false }
 tower-service = { version = "0.3", default-features = false }

--- a/examples/axum-http-service/Cargo.toml
+++ b/examples/axum-http-service/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 tower_otel_http_metrics = { path = "../../", package = "tower-otel-http-metrics", features = ["axum"], default-features = false }
 axum = { features = ["http1", "tokio"], version = "0.7", default-features = false }
 bytes = { version = "1", default-features = false }
-opentelemetry = { version = "0.26", default-features = false }
-opentelemetry_sdk = { version = "0.26", features = ["rt-tokio"], default-features = false }
-opentelemetry-semantic-conventions = { version = "0.26", default-features = false }
-opentelemetry-otlp = { version = "0.26", features = ["metrics", "grpc-tonic"], default-features = false }
+opentelemetry = { version = "0.27", default-features = false }
+opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"], default-features = false }
+opentelemetry-semantic-conventions = { version = "0.27", default-features = false }
+opentelemetry-otlp = { version = "0.27", features = ["metrics", "grpc-tonic"], default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread"], default-features = false }

--- a/examples/axum-http-service/src/main.rs
+++ b/examples/axum-http-service/src/main.rs
@@ -23,10 +23,10 @@ fn init_otel_resource() -> Resource {
             Box::new(TelemetryResourceDetector),
         ],
     );
-    let otlp_resource_override = Resource::new(vec![KeyValue {
-        key: opentelemetry_semantic_conventions::resource::SERVICE_NAME.into(),
-        value: SERVICE_NAME.into(),
-    }]);
+    let otlp_resource_override = Resource::new(vec![KeyValue::new(
+        opentelemetry_semantic_conventions::resource::SERVICE_NAME,
+        SERVICE_NAME,
+    )]);
     otlp_resource_detected.merge(&otlp_resource_override)
 }
 
@@ -40,17 +40,24 @@ async fn main() {
     // https://docs.rs/opentelemetry-otlp/latest/opentelemetry_otlp/#kitchen-sink-full-configuration
     // this configuration interface is annoyingly slightly different from the tracing one
     // also the above documentation is outdated, it took awhile to get this correct one working
-    let meter_provider = opentelemetry_otlp::new_pipeline()
-        .metrics(opentelemetry_sdk::runtime::Tokio)
-        .with_exporter(
-            opentelemetry_otlp::new_exporter()
-                .tonic()
-                .with_endpoint("http://localhost:4317"),
-        )
-        .with_resource(init_otel_resource().clone())
-        .with_period(Duration::from_secs(10))
-        .build() // build registers the global meter provider
+
+    let exporter = opentelemetry_otlp::MetricExporter::builder()
+        .with_tonic()
+        .with_endpoint("http://localhost:4317")
+        .build()
         .unwrap();
+
+    let reader = opentelemetry_sdk::metrics::PeriodicReader::builder(
+        exporter,
+        opentelemetry_sdk::runtime::Tokio,
+    )
+    .with_interval(std::time::Duration::from_secs(10))
+    .build();
+
+    let meter_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+        .with_reader(reader)
+        .with_resource(init_otel_resource())
+        .build();
 
     global::set_meter_provider(meter_provider);
     // init our otel metrics middleware

--- a/examples/tower-http-service/Cargo.toml
+++ b/examples/tower-http-service/Cargo.toml
@@ -11,10 +11,10 @@ bytes = { version = "1", default-features = false }
 hyper = { version = "1", default-features = false }
 http-body-util = { version = "0.1", default-features = false }
 hyper-util = { version = "0.1", features = ["http1", "service", "server", "tokio"], default-features = false }
-opentelemetry = { version = "0.26", default-features = false }
-opentelemetry_sdk = { version = "0.26", features = ["rt-tokio"], default-features = false }
-opentelemetry-semantic-conventions = { version = "0.26", default-features = false }
-opentelemetry-otlp = { version = "0.26", features = ["grpc-tonic", "metrics"], default-features = false }
+opentelemetry = { version = "0.27", default-features = false }
+opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"], default-features = false }
+opentelemetry-semantic-conventions = { version = "0.27", default-features = false }
+opentelemetry-otlp = { version = "0.27", features = ["grpc-tonic", "metrics"], default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"], default-features = false }
 tower = { version = "0.5", default-features = false }
 tower-http = { version = "0.6", default-features = false }

--- a/examples/tower-http-service/src/main.rs
+++ b/examples/tower-http-service/src/main.rs
@@ -28,10 +28,10 @@ fn init_otel_resource() -> Resource {
             Box::new(TelemetryResourceDetector),
         ],
     );
-    let otlp_resource_override = Resource::new(vec![KeyValue {
-        key: opentelemetry_semantic_conventions::resource::SERVICE_NAME.into(),
-        value: SERVICE_NAME.into(),
-    }]);
+    let otlp_resource_override = Resource::new(vec![KeyValue::new(
+        opentelemetry_semantic_conventions::resource::SERVICE_NAME,
+        SERVICE_NAME,
+    )]);
     otlp_resource_detected.merge(&otlp_resource_override)
 }
 
@@ -45,17 +45,23 @@ async fn main() {
     // https://docs.rs/opentelemetry-otlp/latest/opentelemetry_otlp/#kitchen-sink-full-configuration
     // this configuration interface is annoyingly slightly different from the tracing one
     // also the above documentation is outdated, it took awhile to get this correct one working
-    let meter_provider = opentelemetry_otlp::new_pipeline()
-        .metrics(opentelemetry_sdk::runtime::Tokio)
-        .with_exporter(
-            opentelemetry_otlp::new_exporter()
-                .tonic()
-                .with_endpoint("http://localhost:4317"),
-        )
-        .with_resource(init_otel_resource().clone())
-        .with_period(Duration::from_secs(10))
-        .build() // build registers the global meter provider
+    let exporter = opentelemetry_otlp::MetricExporter::builder()
+        .with_tonic()
+        .with_endpoint("http://localhost:4317")
+        .build()
         .unwrap();
+
+    let reader = opentelemetry_sdk::metrics::PeriodicReader::builder(
+        exporter,
+        opentelemetry_sdk::runtime::Tokio,
+    )
+    .with_interval(std::time::Duration::from_secs(10))
+    .build();
+
+    let meter_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+        .with_reader(reader)
+        .with_resource(init_otel_resource())
+        .build();
 
     global::set_meter_provider(meter_provider);
     // init our otel metrics middleware

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,6 @@ const HTTP_SERVER_ACTIVE_REQUESTS_UNIT: &str = "{request}";
 const HTTP_SERVER_REQUEST_BODY_SIZE_METRIC: &str = "http.server.request.body.size";
 const HTTP_SERVER_REQUEST_BODY_SIZE_UNIT: &str = "By";
 
-
 const HTTP_REQUEST_METHOD_LABEL: &str = "http.request.method";
 const HTTP_ROUTE_LABEL: &str = "http.route";
 const HTTP_RESPONSE_STATUS_CODE_LABEL: &str = "http.response.status_code";
@@ -130,17 +129,17 @@ impl HTTPMetricsLayerBuilder {
                 .with_description("Duration of HTTP server requests.")
                 .with_unit(Cow::from(HTTP_SERVER_DURATION_UNIT))
                 .with_boundaries(HTTP_SERVER_DURATION_BOUNDARIES.to_vec())
-                .init(),
+                .build(),
             server_active_requests: meter
                 .i64_up_down_counter(Cow::from(HTTP_SERVER_ACTIVE_REQUESTS_METRIC))
                 .with_description("Number of active HTTP server requests.")
                 .with_unit(Cow::from(HTTP_SERVER_ACTIVE_REQUESTS_UNIT))
-                .init(),
+                .build(),
             server_request_body_size: meter
                 .u64_histogram(HTTP_SERVER_REQUEST_BODY_SIZE_METRIC)
                 .with_description("Size of HTTP server request bodies.")
                 .with_unit(HTTP_SERVER_REQUEST_BODY_SIZE_UNIT)
-                .init(),
+                .build(),
         }
     }
 }


### PR DESCRIPTION
I ran into version incompatibilities after bumping my project to [opentelemetry 0.27](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-otlp/CHANGELOG.md#0270):

```
error[E0308]: mismatched types
   --> nar-bridge/src/lib.rs:47:21
    |
47  |         .with_meter(metrics_meter)
    |          ---------- ^^^^^^^^^^^^^ expected `opentelemetry::metrics::meter::Meter`, found `Meter`
    |          |
    |          arguments to this method are incorrect
    |
    = note: `Meter` and `opentelemetry::metrics::meter::Meter` have similar names, but are actually distinct types
note: `Meter` is defined in crate `opentelemetry`
   --> /home/flokli/.cargo/registry/src/index.crates.io-6f17d22bba15001f/opentelemetry-0.27.0/src/metrics/meter.rs:298:1
    |
298 | pub struct Meter {
    | ^^^^^^^^^^^^^^^^
note: `opentelemetry::metrics::meter::Meter` is defined in crate `opentelemetry`
   --> /home/flokli/.cargo/registry/src/index.crates.io-6f17d22bba15001f/opentelemetry-0.26.0/src/metrics/meter.rs:293:1
    |
293 | pub struct Meter {
    | ^^^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `opentelemetry` are being used?
note: method defined here
   --> /home/flokli/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tower-otel-http-metrics-0.8.0/src/lib.rs:107:12
    |
107 |     pub fn with_meter(self, meter: Meter) -> Self {
    |            ^^^^^^^^^^
```

This updates the dependencies in here to the latest version.

Note doctests failed before and after this PR (due to the code example in the README), but I tried to not introduce new errors in there.