### PR TITLE
upgrade to opentelemetry 0.28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ axum = ["dep:axum"]
 axum = { features = ["matched-path", "macros"], version = "0.7", default-features = false, optional = true }
 futures-util = { version = "0.3", default-features = false }
 http = { version = "1", features = ["std"], default-features = false }
-opentelemetry = { version = "0.27", features = ["metrics"], default-features = false }
+opentelemetry = { version = "0.28", features = ["metrics"], default-features = false }
 pin-project-lite = { version = "0.2", default-features = false }
 tower = { version = "0.5", default-features = false }
 tower-service = { version = "0.3", default-features = false }

--- a/README.md
+++ b/README.md
@@ -16,36 +16,28 @@ Adding OpenTelementry HTTP Server metrics using the [`Axum`](https://docs.rs/axu
 over a Tower-compatible [`Hyper`](https://docs.rs/hyper/latest/hyper) Service:
 
 ```rust
-use std::time::Duration;
-
 use axum::routing::{get, post, put, Router};
 use bytes::Bytes;
-use opentelemetry::{global, KeyValue};
+use opentelemetry::global;
 use opentelemetry_otlp::{
     WithExportConfig, {self},
 };
-use opentelemetry_sdk::resource::{
-    EnvResourceDetector, SdkProvidedResourceDetector, TelemetryResourceDetector,
-};
+use opentelemetry_sdk::metrics::PeriodicReader;
 use opentelemetry_sdk::Resource;
+use std::time::Duration;
 use tower_otel_http_metrics;
 
 const SERVICE_NAME: &str = "example-axum-http-service";
+// Metric export interval should be less than or equal to 15s
+// if the metrics may be converted to Prometheus metrics.
+// Prometheus' query engine and compatible implementations
+// require ~4 data points / interval for range queries,
+// so queries ranging over 1m requre <= 15s scrape intervals.
+// OTEL SDKS also respect the env var `OTEL_METRIC_EXPORT_INTERVAL` (no underscore prefix).
+const _OTEL_METRIC_EXPORT_INTERVAL: Duration = Duration::from_secs(10);
 
 fn init_otel_resource() -> Resource {
-    let otlp_resource_detected = Resource::from_detectors(
-        Duration::from_secs(3),
-        vec![
-            Box::new(SdkProvidedResourceDetector),
-            Box::new(EnvResourceDetector::new()),
-            Box::new(TelemetryResourceDetector),
-        ],
-    );
-    let otlp_resource_override = Resource::new(vec![KeyValue::new(
-        opentelemetry_semantic_conventions::resource::SERVICE_NAME,
-        SERVICE_NAME,
-    )]);
-    otlp_resource_detected.merge(&otlp_resource_override)
+    Resource::builder().with_service_name(SERVICE_NAME).build()
 }
 
 async fn handle() -> Bytes {
@@ -54,28 +46,20 @@ async fn handle() -> Bytes {
 
 #[tokio::main]
 async fn main() {
-    // init otel metrics pipeline
-    // https://docs.rs/opentelemetry-otlp/latest/opentelemetry_otlp/#kitchen-sink-full-configuration
-    // this configuration interface is annoyingly slightly different from the tracing one
-    // also the above documentation is outdated, it took awhile to get this correct one working
     let exporter = opentelemetry_otlp::MetricExporter::builder()
         .with_tonic()
         .with_endpoint("http://localhost:4317")
         .build()
         .unwrap();
 
-    let reader = opentelemetry_sdk::metrics::PeriodicReader::builder(
-        exporter,
-        opentelemetry_sdk::runtime::Tokio,
-    )
-    .with_interval(std::time::Duration::from_secs(10))
-    .build();
+    let reader = PeriodicReader::builder(exporter)
+        .with_interval(_OTEL_METRIC_EXPORT_INTERVAL)
+        .build();
 
     let meter_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
         .with_reader(reader)
         .with_resource(init_otel_resource())
         .build();
-
 
     global::set_meter_provider(meter_provider);
     // init our otel metrics middleware
@@ -106,42 +90,33 @@ Adding OpenTelementry HTTP Server metrics to a bare-bones Tower-compatible Servi
 using [`Hyper`](https://docs.rs/crate/hyper/latest):
 
 ```rust
-use std::convert::Infallible;
-use std::net::SocketAddr;
-use std::time::Duration;
-
 use http_body_util::Full;
 use hyper::body::Bytes;
-use hyper::server::conn::http1;
 use hyper::{Request, Response};
-use opentelemetry::{global, KeyValue};
+use opentelemetry::global;
 use opentelemetry_otlp::{
     WithExportConfig, {self},
 };
-use opentelemetry_sdk::resource::{
-    EnvResourceDetector, SdkProvidedResourceDetector, TelemetryResourceDetector,
-};
+use opentelemetry_sdk::metrics::PeriodicReader;
 use opentelemetry_sdk::Resource;
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::time::Duration;
 use tokio::net::TcpListener;
 use tower::ServiceBuilder;
 use tower_otel_http_metrics;
 
 const SERVICE_NAME: &str = "example-tower-http-service";
+// Metric export interval should be less than or equal to 15s
+// if the metrics may be converted to Prometheus metrics.
+// Prometheus' query engine and compatible implementations
+// require ~4 data points / interval for range queries,
+// so queries ranging over 1m requre <= 15s scrape intervals.
+// OTEL SDKS also respect the env var `OTEL_METRIC_EXPORT_INTERVAL` (no underscore prefix).
+const _OTEL_METRIC_EXPORT_INTERVAL: Duration = Duration::from_secs(10);
 
 fn init_otel_resource() -> Resource {
-    let otlp_resource_detected = Resource::from_detectors(
-        Duration::from_secs(3),
-        vec![
-            Box::new(SdkProvidedResourceDetector),
-            Box::new(EnvResourceDetector::new()),
-            Box::new(TelemetryResourceDetector),
-        ],
-    );
-    let otlp_resource_override = Resource::new(vec![KeyValue::new(
-        opentelemetry_semantic_conventions::resource::SERVICE_NAME,
-        SERVICE_NAME,
-    )]);
-    otlp_resource_detected.merge(&otlp_resource_override)
+    Resource::builder().with_service_name(SERVICE_NAME).build()
 }
 
 async fn handle(_req: Request<hyper::body::Incoming>) -> Result<Response<Full<Bytes>>, Infallible> {
@@ -150,22 +125,15 @@ async fn handle(_req: Request<hyper::body::Incoming>) -> Result<Response<Full<By
 
 #[tokio::main]
 async fn main() {
-    // init otel metrics pipeline
-    // https://docs.rs/opentelemetry-otlp/latest/opentelemetry_otlp/#kitchen-sink-full-configuration
-    // this configuration interface is annoyingly slightly different from the tracing one
-    // also the above documentation is outdated, it took awhile to get this correct one working
     let exporter = opentelemetry_otlp::MetricExporter::builder()
         .with_tonic()
         .with_endpoint("http://localhost:4317")
         .build()
         .unwrap();
 
-    let reader = opentelemetry_sdk::metrics::PeriodicReader::builder(
-        exporter,
-        opentelemetry_sdk::runtime::Tokio,
-    )
-    .with_interval(std::time::Duration::from_secs(10))
-    .build();
+    let reader = PeriodicReader::builder(exporter)
+        .with_interval(_OTEL_METRIC_EXPORT_INTERVAL)
+        .build();
 
     let meter_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
         .with_reader(reader)
@@ -185,7 +153,7 @@ async fn main() {
         .service_fn(handle);
     let hyper_service = hyper_util::service::TowerToHyperService::new(tower_service);
 
-    let addr = SocketAddr::from(([127, 0, 0, 1], 5000));
+    let addr = SocketAddr::from(([0, 0, 0, 0], 5000));
     let listener = TcpListener::bind(addr).await.unwrap();
 
     loop {
@@ -195,9 +163,10 @@ async fn main() {
         let service_clone = hyper_service.clone();
 
         tokio::task::spawn(async move {
-            if let Err(err) = http1::Builder::new()
-                .serve_connection(io, service_clone)
-                .await
+            if let Err(err) =
+                hyper_util::server::conn::auto::Builder::new(hyper_util::rt::TokioExecutor::new())
+                    .serve_connection(io, service_clone)
+                    .await
             {
                 eprintln!("server error: {}", err);
             }

--- a/examples/axum-http-service/Cargo.toml
+++ b/examples/axum-http-service/Cargo.toml
@@ -9,8 +9,7 @@ edition = "2021"
 tower_otel_http_metrics = { path = "../../", package = "tower-otel-http-metrics", features = ["axum"], default-features = false }
 axum = { features = ["http1", "tokio"], version = "0.7", default-features = false }
 bytes = { version = "1", default-features = false }
-opentelemetry = { version = "0.27", default-features = false }
-opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"], default-features = false }
-opentelemetry-semantic-conventions = { version = "0.27", default-features = false }
-opentelemetry-otlp = { version = "0.27", features = ["metrics", "grpc-tonic"], default-features = false }
+opentelemetry = { version = "0.28", default-features = false }
+opentelemetry_sdk = { version = "0.28", features = ["rt-tokio"], default-features = false }
+opentelemetry-otlp = { version = "0.28", features = ["grpc-tonic", "metrics"], default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread"], default-features = false }

--- a/examples/axum-http-service/src/main.rs
+++ b/examples/axum-http-service/src/main.rs
@@ -4,10 +4,19 @@ use opentelemetry::global;
 use opentelemetry_otlp::{
     WithExportConfig, {self},
 };
+use opentelemetry_sdk::metrics::PeriodicReader;
 use opentelemetry_sdk::Resource;
+use std::time::Duration;
 use tower_otel_http_metrics;
 
 const SERVICE_NAME: &str = "example-axum-http-service";
+// Metric export interval should be less than or equal to 15s
+// if the metrics may be converted to Prometheus metrics.
+// Prometheus' query engine and compatible implementations
+// require ~4 data points / interval for range queries,
+// so queries ranging over 1m requre <= 15s scrape intervals.
+// OTEL SDKS also respect the env var `OTEL_METRIC_EXPORT_INTERVAL` (no underscore prefix).
+const _OTEL_METRIC_EXPORT_INTERVAL: Duration = Duration::from_secs(10);
 
 fn init_otel_resource() -> Resource {
     Resource::builder().with_service_name(SERVICE_NAME).build()
@@ -19,19 +28,18 @@ async fn handle() -> Bytes {
 
 #[tokio::main]
 async fn main() {
-    // init otel metrics pipeline
-    // https://docs.rs/opentelemetry-otlp/latest/opentelemetry_otlp/#kitchen-sink-full-configuration
-    // this configuration interface is annoyingly slightly different from the tracing one
-    // also the above documentation is outdated, it took awhile to get this correct one working
-
     let exporter = opentelemetry_otlp::MetricExporter::builder()
         .with_tonic()
         .with_endpoint("http://localhost:4317")
         .build()
         .unwrap();
 
+    let reader = PeriodicReader::builder(exporter)
+        .with_interval(_OTEL_METRIC_EXPORT_INTERVAL)
+        .build();
+
     let meter_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
-        .with_periodic_exporter(exporter)
+        .with_reader(reader)
         .with_resource(init_otel_resource())
         .build();
 

--- a/examples/tower-http-service/Cargo.toml
+++ b/examples/tower-http-service/Cargo.toml
@@ -11,10 +11,9 @@ bytes = { version = "1", default-features = false }
 hyper = { version = "1", default-features = false }
 http-body-util = { version = "0.1", default-features = false }
 hyper-util = { version = "0.1", features = ["http1", "service", "server", "tokio"], default-features = false }
-opentelemetry = { version = "0.27", default-features = false }
-opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"], default-features = false }
-opentelemetry-semantic-conventions = { version = "0.27", default-features = false }
-opentelemetry-otlp = { version = "0.27", features = ["grpc-tonic", "metrics"], default-features = false }
+opentelemetry = { version = "0.28", default-features = false }
+opentelemetry_sdk = { version = "0.28", features = ["rt-tokio"], default-features = false }
+opentelemetry-otlp = { version = "0.28", features = ["grpc-tonic", "metrics"], default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"], default-features = false }
 tower = { version = "0.5", default-features = false }
 tower-http = { version = "0.6", default-features = false }

--- a/examples/tower-http-service/Cargo.toml
+++ b/examples/tower-http-service/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [dependencies]
 tower_otel_http_metrics = { path = "../../", package = "tower-otel-http-metrics", features = ["axum"], default-features = false }
-bytes = { version = "1", default-features = false }
 hyper = { version = "1", default-features = false }
 http-body-util = { version = "0.1", default-features = false }
 hyper-util = { version = "0.1", features = ["http1", "service", "server", "tokio"], default-features = false }
@@ -16,4 +15,3 @@ opentelemetry_sdk = { version = "0.28", features = ["rt-tokio"], default-feature
 opentelemetry-otlp = { version = "0.28", features = ["grpc-tonic", "metrics"], default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"], default-features = false }
 tower = { version = "0.5", default-features = false }
-tower-http = { version = "0.6", default-features = false }


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-rust/blob/main/docs/migration_0.28.md provides an overview over the necessary migration steps.

Most notably, we don't need to manually add detectors, as the Resource::builder() automatically configures the three detectors we manually added. Setting the service name is also less manual.

Additionally, we can use the .with_periodic_exporter() helper in the MeterProviderBuilder to pass our exporters directly, without needing to manually construct a PeriodicReader.

This overall reduces the amount of boilerplate.

Fixes #16.