### PR TITLE
enable custom request duration bucket boundaries & change default boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ async fn main() {
     global::set_meter_provider(meter_provider);
     // init our otel metrics middleware
     let global_meter = global::meter(SERVICE_NAME);
-    let otel_metrics_service_layer = tower_otel_http_metrics::HTTPMetricsLayerBuilder::new()
+    let otel_metrics_service_layer = tower_otel_http_metrics::HTTPMetricsLayerBuilder::builder()
         .with_meter(global_meter)
         .build()
         .unwrap();
@@ -143,7 +143,7 @@ async fn main() {
     global::set_meter_provider(meter_provider);
     // init our otel metrics middleware
     let global_meter = global::meter(SERVICE_NAME);
-    let otel_metrics_service_layer = tower_otel_http_metrics::HTTPMetricsLayerBuilder::new()
+    let otel_metrics_service_layer = tower_otel_http_metrics::HTTPMetricsLayerBuilder::builder()
         .with_meter(global_meter)
         .build()
         .unwrap();

--- a/README.md
+++ b/README.md
@@ -40,8 +40,22 @@ fn init_otel_resource() -> Resource {
     Resource::builder().with_service_name(SERVICE_NAME).build()
 }
 
+// PCT_SLOW_REQUESTS and MAX_SLOW_REQUEST_SEC are used to inject latency into some responses
+// in order to utilize the higher request duration buckets in the request duration histogram.
+// These values are chosen so that with the load-gen script's max 100 VUs, we get just enough
+// slow requests to show up on the histograms without completely blocking up the server.
+const PCT_SLOW_REQUESTS: u64 = 5;
+const MAX_SLOW_REQUEST_SEC: u64 = 16;
+const MAX_BODY_SIZE_MULTIPLE: u64 = 128;
+
+#[axum::debug_handler]
 async fn handle() -> Bytes {
-    Bytes::from("hello, world")
+    if rand_09::random_range(0..100) < PCT_SLOW_REQUESTS {
+        let slow_request_secs = rand_09::random_range(0..=MAX_SLOW_REQUEST_SEC);
+        tokio::time::sleep(Duration::from_secs(slow_request_secs)).await;
+    };
+    let body_size_multiple = rand_09::random_range(0..=MAX_BODY_SIZE_MULTIPLE);
+    Bytes::from("{'msg': 'hello world'}".repeat(body_size_multiple as usize))
 }
 
 #[tokio::main]
@@ -119,8 +133,22 @@ fn init_otel_resource() -> Resource {
     Resource::builder().with_service_name(SERVICE_NAME).build()
 }
 
+// PCT_SLOW_REQUESTS and MAX_SLOW_REQUEST_SEC are used to inject latency into some responses
+// in order to utilize the higher request duration buckets in the request duration histogram.
+// These values are chosen so that with the load-gen script's max 100 VUs, we get just enough
+// slow requests to show up on the histograms without completely blocking up the server.
+const PCT_SLOW_REQUESTS: u64 = 5;
+const MAX_SLOW_REQUEST_SEC: u64 = 16;
+const MAX_BODY_SIZE_MULTIPLE: u64 = 128;
+
 async fn handle(_req: Request<hyper::body::Incoming>) -> Result<Response<Full<Bytes>>, Infallible> {
-    Ok(Response::new(Full::new(Bytes::from("hello, world"))))
+    if rand_09::random_range(0..100) < PCT_SLOW_REQUESTS {
+        let slow_request_secs = rand_09::random_range(0..=MAX_SLOW_REQUEST_SEC);
+        tokio::time::sleep(Duration::from_secs(slow_request_secs)).await;
+    };
+    let body_size_multiple = rand_09::random_range(0..=MAX_BODY_SIZE_MULTIPLE);
+    let body = Bytes::from("{'msg': 'hello world'}".repeat(body_size_multiple as usize));
+    Ok(Response::new(Full::new(body)))
 }
 
 #[tokio::main]

--- a/development/load-gen/echo-all.js
+++ b/development/load-gen/echo-all.js
@@ -1,10 +1,10 @@
-import { sleep } from 'k6';
+import {sleep} from 'k6';
 import http from 'k6/http';
 
 // run for an hour in fluctuating 1-minute stages
 let stages = [];
 for (let i = 0; i < 60; i++) {
-    stages.push({duration: '1m', target: Math.floor(Math.random() * 10)});
+    stages.push({duration: '1m', target: Math.floor(Math.random() * 100)});
 }
 
 export const options = {
@@ -23,7 +23,7 @@ const supportedMethods = ['GET', 'POST', 'PUT']
 const endpointContentTypes = new Map(
     [
         [echoDefaultEndpoint, 'application/octet-stream'],
-        ]
+    ]
 )
 
 let getRandomArrayItem = (arr) => {

--- a/examples/axum-http-service/Cargo.toml
+++ b/examples/axum-http-service/Cargo.toml
@@ -13,3 +13,4 @@ opentelemetry = { version = "0.28", default-features = false }
 opentelemetry_sdk = { version = "0.28", features = ["rt-tokio"], default-features = false }
 opentelemetry-otlp = { version = "0.28", features = ["grpc-tonic", "metrics"], default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread"], default-features = false }
+rand_09 = { package = "rand", version = "0.9" }

--- a/examples/axum-http-service/src/main.rs
+++ b/examples/axum-http-service/src/main.rs
@@ -46,7 +46,7 @@ async fn main() {
     global::set_meter_provider(meter_provider);
     // init our otel metrics middleware
     let global_meter = global::meter(SERVICE_NAME);
-    let otel_metrics_service_layer = tower_otel_http_metrics::HTTPMetricsLayerBuilder::new()
+    let otel_metrics_service_layer = tower_otel_http_metrics::HTTPMetricsLayerBuilder::builder()
         .with_meter(global_meter)
         .build()
         .unwrap();

--- a/examples/axum-http-service/src/main.rs
+++ b/examples/axum-http-service/src/main.rs
@@ -22,8 +22,22 @@ fn init_otel_resource() -> Resource {
     Resource::builder().with_service_name(SERVICE_NAME).build()
 }
 
+// PCT_SLOW_REQUESTS and MAX_SLOW_REQUEST_SEC are used to inject latency into some responses
+// in order to utilize the higher request duration buckets in the request duration histogram.
+// These values are chosen so that with the load-gen script's max 100 VUs, we get just enough
+// slow requests to show up on the histograms without completely blocking up the server.
+const PCT_SLOW_REQUESTS: u64 = 5;
+const MAX_SLOW_REQUEST_SEC: u64 = 16;
+const MAX_BODY_SIZE_MULTIPLE: u64 = 128;
+
+#[axum::debug_handler]
 async fn handle() -> Bytes {
-    Bytes::from("hello, world")
+    if rand_09::random_range(0..100) < PCT_SLOW_REQUESTS {
+        let slow_request_secs = rand_09::random_range(0..=MAX_SLOW_REQUEST_SEC);
+        tokio::time::sleep(Duration::from_secs(slow_request_secs)).await;
+    };
+    let body_size_multiple = rand_09::random_range(0..=MAX_BODY_SIZE_MULTIPLE);
+    Bytes::from("{'msg': 'hello world'}".repeat(body_size_multiple as usize))
 }
 
 #[tokio::main]

--- a/examples/tower-http-service/Cargo.toml
+++ b/examples/tower-http-service/Cargo.toml
@@ -15,3 +15,4 @@ opentelemetry_sdk = { version = "0.28", features = ["rt-tokio"], default-feature
 opentelemetry-otlp = { version = "0.28", features = ["grpc-tonic", "metrics"], default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"], default-features = false }
 tower = { version = "0.5", default-features = false }
+rand_09 = { package = "rand", version = "0.9" }

--- a/examples/tower-http-service/src/main.rs
+++ b/examples/tower-http-service/src/main.rs
@@ -51,7 +51,7 @@ async fn main() {
     global::set_meter_provider(meter_provider);
     // init our otel metrics middleware
     let global_meter = global::meter(SERVICE_NAME);
-    let otel_metrics_service_layer = tower_otel_http_metrics::HTTPMetricsLayerBuilder::new()
+    let otel_metrics_service_layer = tower_otel_http_metrics::HTTPMetricsLayerBuilder::builder()
         .with_meter(global_meter)
         .build()
         .unwrap();

--- a/examples/tower-http-service/src/main.rs
+++ b/examples/tower-http-service/src/main.rs
@@ -27,8 +27,22 @@ fn init_otel_resource() -> Resource {
     Resource::builder().with_service_name(SERVICE_NAME).build()
 }
 
+// PCT_SLOW_REQUESTS and MAX_SLOW_REQUEST_SEC are used to inject latency into some responses
+// in order to utilize the higher request duration buckets in the request duration histogram.
+// These values are chosen so that with the load-gen script's max 100 VUs, we get just enough
+// slow requests to show up on the histograms without completely blocking up the server.
+const PCT_SLOW_REQUESTS: u64 = 5;
+const MAX_SLOW_REQUEST_SEC: u64 = 16;
+const MAX_BODY_SIZE_MULTIPLE: u64 = 128;
+
 async fn handle(_req: Request<hyper::body::Incoming>) -> Result<Response<Full<Bytes>>, Infallible> {
-    Ok(Response::new(Full::new(Bytes::from("hello, world"))))
+    if rand_09::random_range(0..100) < PCT_SLOW_REQUESTS {
+        let slow_request_secs = rand_09::random_range(0..=MAX_SLOW_REQUEST_SEC);
+        tokio::time::sleep(Duration::from_secs(slow_request_secs)).await;
+    };
+    let body_size_multiple = rand_09::random_range(0..=MAX_BODY_SIZE_MULTIPLE);
+    let body = Bytes::from("{'msg': 'hello world'}".repeat(body_size_multiple as usize));
+    Ok(Response::new(Full::new(body)))
 }
 
 #[tokio::main]


### PR DESCRIPTION
This is to address [issue](https://github.com/francoposa/tower-otel-http-metrics/issues/15).

Essentially, a max request duration bucket of 10 seconds is (in my opinion) far too small to capture the longest likely request durations for an arbitrary http server.

This changes the default *and* allows the library consumers to change this.

It also more carefully follows the builder pattern for initialization & configuration that other OTEL libs use.