### PR TITLE
examples: stop pulling in rt-tokio feature

### DIFF
--- a/examples/axum-http-service/Cargo.toml
+++ b/examples/axum-http-service/Cargo.toml
@@ -10,7 +10,7 @@ tower_otel_http_metrics = { path = "../../", package = "tower-otel-http-metrics"
 axum = { features = ["http1", "tokio"], version = "0.8", default-features = false }
 bytes = { version = "1", default-features = false }
 opentelemetry = { version = "0.28", default-features = false }
-opentelemetry_sdk = { version = "0.28", features = ["rt-tokio"], default-features = false }
+opentelemetry_sdk = { version = "0.28", default-features = false }
 opentelemetry-otlp = { version = "0.28", features = ["grpc-tonic", "metrics"], default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread"], default-features = false }
 rand_09 = { package = "rand", version = "0.9" }

--- a/examples/tower-http-service/Cargo.toml
+++ b/examples/tower-http-service/Cargo.toml
@@ -11,7 +11,7 @@ hyper = { version = "1", default-features = false }
 http-body-util = { version = "0.1", default-features = false }
 hyper-util = { version = "0.1", features = ["http1", "service", "server", "tokio"], default-features = false }
 opentelemetry = { version = "0.28", default-features = false }
-opentelemetry_sdk = { version = "0.28", features = ["rt-tokio"], default-features = false }
+opentelemetry_sdk = { version = "0.28", default-features = false }
 opentelemetry-otlp = { version = "0.28", features = ["grpc-tonic", "metrics"], default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"], default-features = false }
 tower = { version = "0.5", default-features = false }


### PR DESCRIPTION
This feature seems to be not necessary anymore.
See https://github.com/francoposa/tower-otel-http-metrics/pull/17#discussion_r1972757475.