### PR TITLE
Feat: custom attributes via extractors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tower-otel-http-metrics"
 edition = "2021"
-version = "0.14.0"
+version = "0.15.0"
 license = "MIT"
 description = "OpenTelemetry Metrics Middleware for Tower-compatible Rust HTTP servers"
 homepage = "https://github.com/francoposa/tower-otel-http-metrics"

--- a/examples/axum-http-service/src/main.rs
+++ b/examples/axum-http-service/src/main.rs
@@ -1,9 +1,10 @@
+use axum::body::Body;
+use axum::http::{Request, Response};
 use axum::routing::{get, post, put, Router};
 use bytes::Bytes;
 use opentelemetry::global;
-use opentelemetry_otlp::{
-    WithExportConfig, {self},
-};
+use opentelemetry::KeyValue;
+use opentelemetry_otlp;
 use opentelemetry_sdk::metrics::PeriodicReader;
 use opentelemetry_sdk::Resource;
 use std::time::Duration;
@@ -31,14 +32,20 @@ const MAX_SLOW_REQUEST_SEC: u64 = 16;
 // MAX_BODY_SIZE_MULTIPLE is used to demonstrate the `http.server.response.body.size` histogram
 const MAX_BODY_SIZE_MULTIPLE: u64 = 16;
 
+#[derive(Clone)]
+struct CustomExtension(String);
+
 #[axum::debug_handler]
-async fn handle() -> Bytes {
+async fn handle(_request: Request<Body>) -> Response<Body> {
     if rand_09::random_range(0..100) < PCT_SLOW_REQUESTS {
         let slow_request_secs = rand_09::random_range(0..=MAX_SLOW_REQUEST_SEC);
         tokio::time::sleep(Duration::from_secs(slow_request_secs)).await;
     };
     let body_size_multiple = rand_09::random_range(0..=MAX_BODY_SIZE_MULTIPLE);
-    Bytes::from("hello world\n".repeat(body_size_multiple as usize))
+    Response::builder()
+        .extension(CustomExtension("Hello World!".to_string()))
+        .body(Bytes::from("hello world\n".repeat(body_size_multiple as usize)).into())
+        .unwrap()
 }
 
 #[tokio::main]
@@ -59,10 +66,38 @@ async fn main() {
         .build();
 
     global::set_meter_provider(meter_provider);
-    // init our otel metrics middleware
     let global_meter = global::meter(SERVICE_NAME);
+    let request_extractor =
+        tower_otel_http_metrics::FnRequestExtractor::new(|req: &Request<Body>| {
+            let mut attrs = vec![];
+
+            // Add custom attribute based on path length
+            let path_length = req.uri().path().len() as i64;
+            attrs.push(KeyValue::new("http.path.length", path_length));
+
+            // Add custom attribute for query parameter presence
+            let has_query = req.uri().query().is_some();
+            attrs.push(KeyValue::new("http.has_query", has_query));
+
+            attrs
+        });
+
+    let response_extractor =
+        tower_otel_http_metrics::FnResponseExtractor::new(|res: &Response<Body>| {
+            let mut attrs = vec![];
+            if let Some(content_length) = res.extensions().get::<CustomExtension>() {
+                attrs.push(KeyValue::new(
+                    "http.response.custom_extension",
+                    content_length.0.clone(),
+                ));
+            }
+            attrs
+        });
+
     let otel_metrics_service_layer = tower_otel_http_metrics::HTTPMetricsLayerBuilder::builder()
         .with_meter(global_meter)
+        .with_request_extractor(request_extractor)
+        .with_response_extractor(response_extractor)
         .build()
         .unwrap();
 

--- a/examples/hyper-http-service/src/main.rs
+++ b/examples/hyper-http-service/src/main.rs
@@ -2,9 +2,6 @@ use http_body_util::Full;
 use hyper::body::Bytes;
 use hyper::{Request, Response};
 use opentelemetry::global;
-use opentelemetry_otlp::{
-    WithExportConfig, {self},
-};
 use opentelemetry_sdk::metrics::PeriodicReader;
 use opentelemetry_sdk::Resource;
 use std::convert::Infallible;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,74 @@ const HTTP_REQUEST_METHOD_LABEL: &str = "http.request.method";
 const HTTP_ROUTE_LABEL: &str = "http.route";
 const HTTP_RESPONSE_STATUS_CODE_LABEL: &str = "http.response.status_code";
 
+/// Trait for extracting custom attributes from HTTP requests
+pub trait RequestAttributeExtractor<B>: Clone + Send + Sync + 'static {
+    fn extract_attributes(&self, req: &http::Request<B>) -> Vec<KeyValue>;
+}
+
+/// Trait for extracting custom attributes from HTTP responses
+pub trait ResponseAttributeExtractor<B>: Clone + Send + Sync + 'static {
+    fn extract_attributes(&self, res: &http::Response<B>) -> Vec<KeyValue>;
+}
+
+/// Default implementation that extracts no attributes
+#[derive(Clone)]
+pub struct NoOpExtractor;
+
+impl<B> RequestAttributeExtractor<B> for NoOpExtractor {
+    fn extract_attributes(&self, _req: &http::Request<B>) -> Vec<KeyValue> {
+        vec![]
+    }
+}
+
+impl<B> ResponseAttributeExtractor<B> for NoOpExtractor {
+    fn extract_attributes(&self, _res: &http::Response<B>) -> Vec<KeyValue> {
+        vec![]
+    }
+}
+
+/// A function-based request attribute extractor
+#[derive(Clone)]
+pub struct FnRequestExtractor<F> {
+    extractor: F,
+}
+
+impl<F> FnRequestExtractor<F> {
+    pub fn new(extractor: F) -> Self {
+        Self { extractor }
+    }
+}
+
+impl<F, B> RequestAttributeExtractor<B> for FnRequestExtractor<F>
+where
+    F: Fn(&http::Request<B>) -> Vec<KeyValue> + Clone + Send + Sync + 'static,
+{
+    fn extract_attributes(&self, req: &http::Request<B>) -> Vec<KeyValue> {
+        (self.extractor)(req)
+    }
+}
+
+/// A function-based response attribute extractor
+#[derive(Clone)]
+pub struct FnResponseExtractor<F> {
+    extractor: F,
+}
+
+impl<F> FnResponseExtractor<F> {
+    pub fn new(extractor: F) -> Self {
+        Self { extractor }
+    }
+}
+
+impl<F, B> ResponseAttributeExtractor<B> for FnResponseExtractor<F>
+where
+    F: Fn(&http::Response<B>) -> Vec<KeyValue> + Clone + Send + Sync + 'static,
+{
+    fn extract_attributes(&self, res: &http::Response<B>) -> Vec<KeyValue> {
+        (self.extractor)(res)
+    }
+}
+
 /// State scoped to the entire middleware Layer.
 ///
 /// For now the only global state we hold onto is the metrics instruments.
@@ -69,20 +137,26 @@ struct HTTPMetricsLayerState {
 
 #[derive(Clone)]
 /// [`Service`] used by [`HTTPMetricsLayer`]
-pub struct HTTPMetricsService<S> {
+pub struct HTTPMetricsService<S, ReqExt = NoOpExtractor, ResExt = NoOpExtractor> {
     pub(crate) state: Arc<HTTPMetricsLayerState>,
+    request_extractor: ReqExt,
+    response_extractor: ResExt,
     inner_service: S,
 }
 
 #[derive(Clone)]
 /// [`Layer`] which applies the OTEL HTTP server metrics middleware
-pub struct HTTPMetricsLayer {
+pub struct HTTPMetricsLayer<ReqExt = NoOpExtractor, ResExt = NoOpExtractor> {
     state: Arc<HTTPMetricsLayerState>,
+    request_extractor: ReqExt,
+    response_extractor: ResExt,
 }
 
-pub struct HTTPMetricsLayerBuilder {
+pub struct HTTPMetricsLayerBuilder<ReqExt = NoOpExtractor, ResExt = NoOpExtractor> {
     meter: Option<Meter>,
     req_dur_bounds: Option<Vec<f64>>,
+    request_extractor: ReqExt,
+    response_extractor: ResExt,
 }
 
 /// Error typedef to implement `std::error::Error` for `tower_otel_http_metrics`
@@ -90,6 +164,17 @@ pub struct Error {
     #[allow(dead_code)]
     inner: ErrorKind,
 }
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.inner {
+            ErrorKind::Other(ref s) => write!(f, "{}", s),
+            ErrorKind::Config(ref s) => write!(f, "config error: {}", s),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
 
 /// `Result` typedef to use with the `tower_otel_http_metrics::Error` type
 pub type Result<T> = result::Result<T, Error>;
@@ -114,16 +199,76 @@ impl HTTPMetricsLayerBuilder {
         HTTPMetricsLayerBuilder {
             meter: None,
             req_dur_bounds: Some(LIBRARY_DEFAULT_HTTP_SERVER_DURATION_BOUNDARIES.to_vec()),
+            request_extractor: NoOpExtractor,
+            response_extractor: NoOpExtractor,
+        }
+    }
+}
+
+impl<ReqExt, ResExt> HTTPMetricsLayerBuilder<ReqExt, ResExt> {
+    /// Set a request attribute extractor
+    pub fn with_request_extractor<NewReqExt, B>(
+        self,
+        extractor: NewReqExt,
+    ) -> HTTPMetricsLayerBuilder<NewReqExt, ResExt>
+    where
+        NewReqExt: RequestAttributeExtractor<B>,
+    {
+        HTTPMetricsLayerBuilder {
+            meter: self.meter,
+            req_dur_bounds: self.req_dur_bounds,
+            request_extractor: extractor,
+            response_extractor: self.response_extractor,
         }
     }
 
-    pub fn build(self) -> Result<HTTPMetricsLayer> {
+    /// Set a response attribute extractor
+    pub fn with_response_extractor<NewResExt, B>(
+        self,
+        extractor: NewResExt,
+    ) -> HTTPMetricsLayerBuilder<ReqExt, NewResExt>
+    where
+        NewResExt: ResponseAttributeExtractor<B>,
+    {
+        HTTPMetricsLayerBuilder {
+            meter: self.meter,
+            req_dur_bounds: self.req_dur_bounds,
+            request_extractor: self.request_extractor,
+            response_extractor: extractor,
+        }
+    }
+
+    /// Convenience method to set a function-based request extractor
+    pub fn with_request_extractor_fn<F, B>(
+        self,
+        f: F,
+    ) -> HTTPMetricsLayerBuilder<FnRequestExtractor<F>, ResExt>
+    where
+        F: Fn(&http::Request<B>) -> Vec<KeyValue> + Clone + Send + Sync + 'static,
+    {
+        self.with_request_extractor(FnRequestExtractor::new(f))
+    }
+
+    /// Convenience method to set a function-based response extractor
+    pub fn with_response_extractor_fn<F, B>(
+        self,
+        f: F,
+    ) -> HTTPMetricsLayerBuilder<ReqExt, FnResponseExtractor<F>>
+    where
+        F: Fn(&http::Response<B>) -> Vec<KeyValue> + Clone + Send + Sync + 'static,
+    {
+        self.with_response_extractor(FnResponseExtractor::new(f))
+    }
+
+    pub fn build(self) -> Result<HTTPMetricsLayer<ReqExt, ResExt>> {
         let req_dur_bounds = self
             .req_dur_bounds
             .unwrap_or_else(|| LIBRARY_DEFAULT_HTTP_SERVER_DURATION_BOUNDARIES.to_vec());
         match self.meter {
             Some(meter) => Ok(HTTPMetricsLayer {
-                state: Arc::from(HTTPMetricsLayerBuilder::make_state(meter, req_dur_bounds)),
+                state: Arc::from(Self::make_state(meter, req_dur_bounds)),
+                request_extractor: self.request_extractor,
+                response_extractor: self.response_extractor,
             }),
             None => Err(Error {
                 inner: ErrorKind::Config(String::from("no meter provided")),
@@ -133,6 +278,11 @@ impl HTTPMetricsLayerBuilder {
 
     pub fn with_meter(mut self, meter: Meter) -> Self {
         self.meter = Some(meter);
+        self
+    }
+
+    pub fn with_request_duration_bounds(mut self, bounds: Vec<f64>) -> Self {
+        self.req_dur_bounds = Some(bounds);
         self
     }
 
@@ -163,12 +313,18 @@ impl HTTPMetricsLayerBuilder {
     }
 }
 
-impl<S> Layer<S> for HTTPMetricsLayer {
-    type Service = HTTPMetricsService<S>;
+impl<S, ReqExt, ResExt> Layer<S> for HTTPMetricsLayer<ReqExt, ResExt>
+where
+    ReqExt: Clone,
+    ResExt: Clone,
+{
+    type Service = HTTPMetricsService<S, ReqExt, ResExt>;
 
     fn layer(&self, service: S) -> Self::Service {
         HTTPMetricsService {
             state: self.state.clone(),
+            request_extractor: self.request_extractor.clone(),
+            response_extractor: self.response_extractor.clone(),
             inner_service: service,
         }
     }
@@ -194,25 +350,33 @@ struct ResponseFutureMetricsState {
     url_scheme_kv: KeyValue,
     method_kv: KeyValue,
     route_kv_opt: Option<KeyValue>,
+
+    // Custom attributes from request
+    custom_request_attributes: Vec<KeyValue>,
 }
 
 pin_project! {
     /// Response [`Future`] for [`HTTPMetricsService`].
-    pub struct HTTPMetricsResponseFuture<F> {
+    pub struct HTTPMetricsResponseFuture<F, ResExt> {
         #[pin]
         inner_response_future: F,
         layer_state: Arc<HTTPMetricsLayerState>,
         metrics_state: ResponseFutureMetricsState,
+        response_extractor: ResExt,
     }
 }
 
-impl<S, ReqBody, ResBody: http_body::Body> Service<http::Request<ReqBody>> for HTTPMetricsService<S>
+impl<S, ReqBody, ResBody, ReqExt, ResExt> Service<http::Request<ReqBody>>
+    for HTTPMetricsService<S, ReqExt, ResExt>
 where
     S: Service<http::Request<ReqBody>, Response = http::Response<ResBody>>,
+    ResBody: http_body::Body,
+    ReqExt: RequestAttributeExtractor<ReqBody>,
+    ResExt: ResponseAttributeExtractor<ResBody>,
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = HTTPMetricsResponseFuture<S::Future>;
+    type Future = HTTPMetricsResponseFuture<S::Future, ResExt>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<result::Result<(), Self::Error>> {
         self.inner_service.poll_ready(cx)
@@ -246,6 +410,9 @@ where
             ));
         };
 
+        // Extract custom request attributes
+        let custom_request_attributes = self.request_extractor.extract_attributes(&req);
+
         self.state
             .server_active_requests
             .add(1, &[url_scheme_kv.clone(), method_kv.clone()]);
@@ -262,14 +429,18 @@ where
                 url_scheme_kv,
                 method_kv,
                 route_kv_opt,
+                custom_request_attributes,
             },
+            response_extractor: self.response_extractor.clone(),
         }
     }
 }
 
-impl<F, ResBody: http_body::Body, E> Future for HTTPMetricsResponseFuture<F>
+impl<F, ResBody, E, ResExt> Future for HTTPMetricsResponseFuture<F, ResExt>
 where
     F: Future<Output = result::Result<http::Response<ResBody>, E>>,
+    ResBody: http_body::Body,
+    ResExt: ResponseAttributeExtractor<ResBody>,
 {
     type Output = F::Output;
 
@@ -278,8 +449,7 @@ where
         let response = ready!(this.inner_response_future.poll(cx))?;
         let status = response.status();
 
-        // all OTEL `http.server...` metrics use this entire label set,
-        // except `http.server.active_requests`, which only uses a subset
+        // Build base label set
         let mut label_superset = vec![
             this.metrics_state.protocol_name_kv.clone(),
             this.metrics_state.protocol_version_kv.clone(),
@@ -287,9 +457,17 @@ where
             this.metrics_state.method_kv.clone(),
             KeyValue::new(HTTP_RESPONSE_STATUS_CODE_LABEL, i64::from(status.as_u16())),
         ];
+
         if let Some(route_kv) = this.metrics_state.route_kv_opt.clone() {
             label_superset.push(route_kv);
         }
+
+        // Add custom request attributes
+        label_superset.extend(this.metrics_state.custom_request_attributes.clone());
+
+        // Extract and add custom response attributes
+        let custom_response_attributes = this.response_extractor.extract_attributes(&response);
+        label_superset.extend(custom_response_attributes);
 
         this.layer_state.server_request_duration.record(
             this.metrics_state.duration_start.elapsed().as_secs_f64(),


### PR DESCRIPTION
Hello again! Thanks once more for the awesome library.

For my use case, it would be really helpful to be able to attach custom attributes to the Otel metrics so that i can get better granularity on the server performance, and so I've opened this PR that allows exactly that. The way this is achieved is by adding two new traits that the user can implement in order to extract this attributes from request and/or response (or their extensions). The default extractor is a no-op so the change is not a breaking one. Also, a struct is provided that impls the trait in order to provide a ergonomic API where users could pass in closures without needing to make their own struct.

wdyt? would you be open to adding such a feature? Thanks and I'm keen to hear your feedback!